### PR TITLE
Give the InsertKatexButton the type "button"

### DIFF
--- a/src/components/InsertKatexButton.js
+++ b/src/components/InsertKatexButton.js
@@ -27,7 +27,7 @@ export default class InsertKatexButton extends Component {
     const content = Children.count(children) ? children : defaultContent;
 
     return (
-      <button className={combinedClassName} onClick={this.onClick}>
+      <button className={combinedClassName} onClick={this.onClick} type="button">
         {content}
       </button>
     );


### PR DESCRIPTION
According to the HTML spec[1] the default type of a `<button>` element is submit. This means, that the katex-button (if it is included in a form, which most editor buttons are ;)) will receive the submit-action. Thus, if a user presses the `enter`-key in a random form-field the katex button will get triggered instead of the intended submit-action.

Since the katex-button should not submit forms but act as a normal button, it needs the type "button".

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type