### PR TITLE
Prevent unnecessary TeX block rerendering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,17 @@ export default (config = {}) => {
   };
 
   const liveTeXEdits = new Map();
+
+  const component = decorateComponentWithProps(TeXBlock, {
+    theme,
+    store,
+    doneContent,
+    removeContent,
+    translator,
+    katex,
+    MathInput: config.MathInput,
+  });
+
   return {
     initialize: ({ getEditorState, setEditorState, getReadOnly, setReadOnly }) => {
       store.getEditorState = getEditorState;
@@ -64,15 +75,7 @@ export default (config = {}) => {
 
         if (type === 'KateX') {
           return {
-            component: decorateComponentWithProps(TeXBlock, {
-              theme,
-              store,
-              doneContent,
-              removeContent,
-              translator,
-              katex,
-              MathInput: config.MathInput,
-            }),
+            component,
             editable: false,
             props: {
               onStartEdit: blockKey => {


### PR DESCRIPTION
Before, a new decorated `TeXBlock` component was created on each call to the `blockRenderFn` which caused existing `TeXBlock` components to be unmounted and new ones mounted. That meant, that the `componentWillReceiveProps` optimization in the `KaTeXOutput` component wasn't effective.

Since the props used for decorating do not change over time, we can instead only create the decorated `TexBlock` component once, when the plugin is configured.

Before, we saw quite a bit of flickering when typing into an editor which was quite tiring.

Now it's completely smooth 😃 

cc @tessi 